### PR TITLE
Allow pd.DataFrame as input for get_distance_metric

### DIFF
--- a/mood/distance.py
+++ b/mood/distance.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 
 from typing import Optional, Union, List
 
@@ -12,6 +13,8 @@ def get_distance_metric(example):
     metric = "euclidean"
 
     # For binary vectors we use jaccard
+    if isinstance(example, pd.DataFrame):
+        example = example.values  # DataFrames would require all().all() otherwise
     if ((example == 0) | (example == 1)).all():
         metric = "jaccard"
 


### PR DESCRIPTION
Hi,

I encountered a `ValueError: The truth value of a Series is ambiguous` while using one of the splitting methods implemented on MOOD. This error was triggered when a pandas DataFrame was passed as the `X` input for `self.split()`, which would later raise the error on the `if ((example == 0) | (example == 1)).all():` check.

To address this, I modified `get_distance_metric` so that whenever `example` is a pandas DataFrame, it will run the binary check on the `df.values` instead. This change allows DataFrames to be processed without raising the error, providing more flexibility.

I've tested my fix and it resolved the issue. I also saw you use `black` as code formatter so I made sure to run it as well after adding my changes.