### PR TITLE
chore: Update references to the GCS bucket to the new HTTP URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ mood --help
 ```
 
 ### Data
-All data has been made available in a public GCP bucket. See [`gs://mood-data-public`](https://storage.googleapis.com/mood-data-public/).
+All data has been made available in a public bucket. See [`https://storage.valencelabs.com/mood-data/`](https://storage.valencelabs.com/mood-data/).
 
 ### Code
 - `mood/`: This is the main part of the codebase. It contains Python implementations of several reusable components and defines the CLI.

--- a/mood/constants.py
+++ b/mood/constants.py
@@ -10,12 +10,12 @@ CACHE_DIR = dm.fs.get_cache_dir("MOOD")
 For the downstream applications (optimization and virtual screening)
 we save all related data to this directory
 """
-DOWNSTREAM_APPS_DATA_DIR = "gs://mood-data-public/downstream_applications/"
+DOWNSTREAM_APPS_DATA_DIR = "https://storage.valencelabs.com/mood-data/downstream_applications/"
 
 """
 Where the results of MOOD are saved
 """
-RESULTS_DIR = "gs://mood-data-public/results/"
+RESULTS_DIR = "https://storage.valencelabs.com/mood-data/results/"
 
 """
 The two downstream applications we consider for MOOD as application areas of molecular scoring
@@ -25,7 +25,7 @@ SUPPORTED_DOWNSTREAM_APPS = ["virtual_screening", "optimization"]
 """
 Where data related to specific datasets is saved
 """
-DATASET_DATA_DIR = "gs://mood-data-public/datasets/"
+DATASET_DATA_DIR = "https://storage.valencelabs.com/mood-data/datasets/"
 
 
 """The number of epochs to train NNs for"""


### PR DESCRIPTION
# Description

This PR updates the hard-coded path from the previous GCS bucket to the new Cloudflare storage bucket.
